### PR TITLE
create symlink as simple fix to wiki build pipeline

### DIFF
--- a/docs/bio-modules-18.04.md
+++ b/docs/bio-modules-18.04.md
@@ -1,0 +1,1 @@
+sw_inventory/gizmo-bio-modules-18.04.md


### PR DESCRIPTION
The other way to fix this would be to add a few lines of code [here](https://github.com/FredHutch/wiki/blob/main/.gitlab-ci.yml) To first figure out where the source file is.

Without one of these fixes, any existing wiki branches will fail to build unless you first merge with the wiki main branch. Which isn't a bad solution either but there are a lot of open branches.