### PR TITLE
Add bubblewrap 0.11.1 and libcap 2.69 for GCCcore-12.3.0

### DIFF
--- a/easyconfigs/b/bubblewrap/bubblewrap-0.11.1-GCCcore-12.3.0.eb
+++ b/easyconfigs/b/bubblewrap/bubblewrap-0.11.1-GCCcore-12.3.0.eb
@@ -1,0 +1,64 @@
+# easybuild easyconfig
+#
+# Dominik Otto dotto@fredhutch.org
+#
+# Fred Hutchinson Cancer Center
+#
+easyblock = 'MesonNinja'
+
+name = 'bubblewrap'
+version = '0.11.1'
+
+homepage = 'https://github.com/containers/bubblewrap'
+description = """Unprivileged sandboxing tool. bubblewrap runs an application
+ in a sandbox, where it has restricted access to parts of the operating system
+ or user data such as the home directory. Used by Flatpak and similar projects."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+source_urls = ['https://github.com/containers/bubblewrap/releases/download/v%(version)s']
+sources = ['%(name)s-%(version)s.tar.xz']
+checksums = ['c1b7455a1283b1295879a46d5f001dfd088c0bb0f238abb5e128b3583a246f71']
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Meson', '1.1.1'),
+    ('Ninja', '1.11.1'),
+    ('pkgconf', '1.9.5'),
+]
+
+dependencies = [
+    ('libcap', '2.69'),
+]
+
+configopts = '-Dman=disabled '
+
+# On Ubuntu 24.04+ with kernel.apparmor_restrict_unprivileged_userns=1,
+# bwrap needs an AppArmor profile granting userns to create user namespaces.
+# Install the profile template; a privileged postinstall step must deploy it:
+#   cp %(installdir)s/etc/apparmor.d/bwrap-easybuild /etc/apparmor.d/
+#   apparmor_parser -r /etc/apparmor.d/bwrap-easybuild
+postinstallcmds = [
+    "mkdir -p %(installdir)s/etc/apparmor.d",
+    """echo 'abi <abi/4.0>,
+include <tunables/global>
+profile bwrap-easybuild %(installdir)s/bin/bwrap flags=(unconfined) {
+  userns,
+}
+' > %(installdir)s/etc/apparmor.d/bwrap-easybuild""",
+]
+
+sanity_check_paths = {
+    'files': ['bin/bwrap', 'etc/apparmor.d/bwrap-easybuild'],
+    'dirs': [],
+}
+
+sanity_check_commands = ['bwrap --version']
+
+modloadmsg = """NOTE: On systems with AppArmor unprivileged userns restrictions
+(Ubuntu 24.04+), a privileged user must install the AppArmor profile:
+  sudo cp %(installdir)s/etc/apparmor.d/bwrap-easybuild /etc/apparmor.d/
+  sudo apparmor_parser -r /etc/apparmor.d/bwrap-easybuild
+"""
+
+moduleclass = 'tools'

--- a/easyconfigs/l/libcap/libcap-2.69-GCCcore-12.3.0.eb
+++ b/easyconfigs/l/libcap/libcap-2.69-GCCcore-12.3.0.eb
@@ -1,0 +1,47 @@
+# easybuild easyconfig
+#
+# Dominik Otto dotto@fredhutch.org
+#
+# Fred Hutchinson Cancer Center
+#
+easyblock = 'ConfigureMake'
+
+name = 'libcap'
+version = '2.69'
+
+homepage = 'https://sites.google.com/site/fullycapable/'
+description = """libcap is a library for getting and setting POSIX.1e
+ (formerly POSIX 6) draft 15 capabilities. Required as a dependency for
+ bubblewrap and other sandboxing tools."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+source_urls = ['https://mirrors.edge.kernel.org/pub/linux/libs/security/linux-privs/libcap2']
+sources = [SOURCE_TAR_XZ]
+checksums = ['f311f8f3dad84699d0566d1d6f7ec943a9298b28f714cae3c931dfd57492d7eb']
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+# libcap uses a plain Makefile, not autotools/configure
+skipsteps = ['configure']
+
+# Build with PIC, install into easybuild prefix, skip the PAM module
+# (pam_cap requires libpam-dev which is a system package we do not depend on)
+buildopts = 'lib=lib GOLANG=no'
+installopts = 'lib=lib GOLANG=no prefix=%(installdir)s DESTDIR='
+
+sanity_check_paths = {
+    'files': [
+        'lib/libcap.%s' % SHLIB_EXT,
+        'lib/libcap.a',
+        'lib/pkgconfig/libcap.pc',
+        'include/sys/capability.h',
+        'sbin/setcap',
+        'sbin/getcap',
+    ],
+    'dirs': ['lib', 'include', 'sbin'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
## Summary

Updates the bubblewrap easyconfig from 0.3.1 (foss-2016b, ConfigureMake) to 0.11.1 (GCCcore-12.3.0, MesonNinja), and adds a new libcap 2.69 easyconfig as a required dependency.

Upstream changes in bubblewrap since 0.3.1:
- Build system switched from Autotools to Meson (Autotools removed entirely)
- Source repo moved from `projectatomic/bubblewrap` to `containers/bubblewrap`
- New overlay mount options (`--overlay`, `--tmp-overlay`, `--ro-overlay`)
- `--[ro-]bind-fd` for TOCTOU-safe mounts (CVE-2024-42472 mitigation)

### Why libcap is in this PR

libcap is a required runtime dependency of bubblewrap. It is not present in the upstream easybuilders/easybuild-easyconfigs repo -- I verified by querying the GitHub contents API against both `develop` and `main` branches. The existing `libcap-2.26-foss-2016b.eb` in this repo is too old and uses the wrong toolchain. A new libcap easyconfig is therefore included alongside the bubblewrap one so that `eb bubblewrap-0.11.1-GCCcore-12.3.0.eb --robot` can resolve all dependencies from within this repo plus the bundled EasyBuild easyconfigs.

## Motivation

I ([Dominik Otto](mailto:dotto@fredhutch.org), Setty Lab, Basic Sciences Division) maintain [agent_sandbox](https://github.com/katosh/agent_sandbox), a sandboxing tool for AI coding agents on the Hutch HPC. It uses bubblewrap as its primary sandbox backend (requires >= 0.4.0 for `--chmod`, `--unsetenv`).

The sandbox provides kernel-enforced filesystem isolation: it hides credentials (`~/.ssh`, `~/.aws`, `~/.gnupg`), blocks environment secrets, prevents user enumeration, restricts write access to a single project directory, and wraps Slurm submission so compute-node jobs inherit the same restrictions. Without bubblewrap, the sandbox must fall back to the landlock backend, which offers weaker isolation -- landlock cannot hide paths entirely (files return `EACCES` instead of `ENOENT`), cannot overlay `/etc/passwd` to prevent user enumeration, and cannot provide the tmpwrite home-directory mode that lets agents create temporary files without persisting them.

The current situation on Hutch nodes:

**Ubuntu 18.04 nodes (rhino, gizmo):** The system bubblewrap is 0.2.1 (`apt` only offers 0.2.1), far too old. The existing Lmod easyconfig is 0.3.1, also too old. Without a working bwrap, *no sandbox backend is available at all* -- landlock requires kernel >= 5.13, and firejail is not installed:

```
bwrap:  0.2.1 (need >= 0.4.0 for --chmod, --unsetenv)
Tried:
  bwrap    -- failed (check user namespace support)
  firejail -- binary not found
  landlock -- kernel too old (need >= 5.13)
```

**Ubuntu 24.04 nodes (Harmony Slurm partition):** Bubblewrap is not available as an Lmod module. The system `apt` package provides 0.9.0 (which would work), but a custom-installed binary outside `/usr/bin/` requires an AppArmor profile to function (see below). Without bwrap, agent_sandbox falls back to landlock with the weaker isolation described above.

I have been recommending users install bubblewrap via Linuxbrew, but users have had trouble getting Linuxbrew set up reliably. Having bubblewrap available as an Lmod module would give Hutch users a reliable `module load bubblewrap` path to proper sandboxing on both old and new nodes.

---

## Deployment guide

Merging this PR only adds the easyconfig files to the repo. The following steps are needed to make bubblewrap available to users:

### Step 1: Build both easyconfigs

```bash
eb libcap-2.69-GCCcore-12.3.0.eb
eb bubblewrap-0.11.1-GCCcore-12.3.0.eb
```

Or in one command with dependency resolution:

```bash
eb bubblewrap-0.11.1-GCCcore-12.3.0.eb --robot
```

All other build dependencies are already available on the HPC and resolve from EasyBuild's bundled easyconfigs:
- GCCcore/12.3.0
- Meson/1.1.1-GCCcore-12.3.0
- Ninja/1.11.1-GCCcore-12.3.0
- pkgconf/1.9.5-GCCcore-12.3.0
- binutils/2.40-GCCcore-12.3.0

After this, users on all nodes sharing `/app/modules/` can do:

```bash
module load bubblewrap/0.11.1-GCCcore-12.3.0
bwrap --version   # bubblewrap 0.11.1
```

This is sufficient for **Ubuntu 18.04 nodes** (rhino, gizmo). No further action needed -- user namespaces work without restrictions on kernel 4.15.

### Step 2: AppArmor profile for Ubuntu 24.04 nodes (Harmony)

On Ubuntu 24.04, `kernel.apparmor_restrict_unprivileged_userns=1` blocks unprivileged user namespace creation for binaries without an AppArmor profile. Without this step, `bwrap` will fail with `Permission denied` on Harmony nodes.

The bubblewrap easyconfig uses `postinstallcmds` to generate a profile template at `%(installdir)s/etc/apparmor.d/bwrap-easybuild` with the install path already substituted in. **This only creates a text file inside the install directory -- it does not deploy anything.** AppArmor only reads profiles from `/etc/apparmor.d/` on each individual node, and only when `apparmor_parser` loads them.

`/app/software/` is on a shared filesystem, so the profile template file is *visible* on every node that mounts `/app/`, but visibility is not enforcement. Each Ubuntu 24.04 node still needs the profile loaded locally.

**Option A -- Deploy the EasyBuild profile (recommended for consistency with the Lmod module):**

On each Ubuntu 24.04 node (or in the node provisioning/image):

```bash
sudo cp /app/software/bubblewrap/0.11.1-GCCcore-12.3.0/etc/apparmor.d/bwrap-easybuild /etc/apparmor.d/
sudo apparmor_parser -r /etc/apparmor.d/bwrap-easybuild
```

The profile is specific to the install path and persists across reboots once loaded.

**Option B -- Install the system package instead:**

```bash
sudo apt install bubblewrap   # installs 0.9.0 with AppArmor profile
```

This gives 0.9.0 (not 0.11.1) at `/usr/bin/bwrap` with the AppArmor profile auto-deployed. Simpler, but provides an older version and exists outside the Lmod module system. 0.9.0 meets the >= 0.4.0 minimum required by agent_sandbox.

### Consequence summary

| Step | Scope | Who | Effect if skipped |
|------|-------|-----|-------------------|
| Build libcap + bubblewrap (Step 1) | Once, on build node | EasyBuild admin | No module available; users stuck with Linuxbrew or system 0.2.1 |
| AppArmor profile (Step 2) | Each Ubuntu 24.04 node | Root / provisioning | `bwrap` fails with `Permission denied` on Harmony; falls back to weaker landlock isolation |

## Testing

**End-to-end build on gizmok1 (Ubuntu 18.04, kernel 4.15) with EasyBuild 4.9.4:**

- `eb libcap-2.69-GCCcore-12.3.0.eb` -- COMPLETED in 20s
- `eb bubblewrap-0.11.1-GCCcore-12.3.0.eb --robot` -- COMPLETED in 21s
- `bwrap --version` -- `bubblewrap 0.11.1`
- AppArmor profile generated at `<installdir>/etc/apparmor.d/bwrap-easybuild` with the install path correctly substituted
- Sandbox test passed: `bwrap --ro-bind / / --dev /dev --proc /proc echo ...` returns successfully
- (Test ran in a user-writable scratch prefix, not `/app/software/`)

**Build test on Ubuntu 24.04 (Lima VM, aarch64):**

- Built bubblewrap 0.11.1 from source with Meson/Ninja -- clean build, install, runtime all succeed
- Confirmed custom-path bwrap fails without AppArmor profile on Ubuntu 24.04 (`Permission denied`)
- Confirmed it works after deploying the AppArmor profile (including `--unshare-net`)

**Other verification:**

- Confirmed system bwrap 0.2.1 on rhino02 is rejected by agent_sandbox (too old)
- Confirmed no fallback backend available on rhino02 without homebrew bwrap
- Confirmed libcap is absent from upstream easybuilders/easybuild-easyconfigs (git tree API)

## Author

Dominik Otto, Setty Lab, Basic Sciences Division, Fred Hutch (dotto@fredhutch.org)