### PR TITLE
Add Rust 1.86.0-GCCcore-13.3.0 easyconfig

### DIFF
--- a/easyconfigs/r/Rust/Rust-1.86.0-GCCcore-13.3.0.eb
+++ b/easyconfigs/r/Rust/Rust-1.86.0-GCCcore-13.3.0.eb
@@ -1,0 +1,31 @@
+name = 'Rust'
+version = '1.86.0'
+
+homepage = 'https://www.rust-lang.org'
+description = """Rust is a systems programming language that runs blazingly fast, prevents segfaults,
+ and guarantees thread safety."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://static.rust-lang.org/dist/']
+sources = ['rustc-%(version)s-src.tar.gz']
+patches = ['Rust-1.70_sysroot-fix-interpreter.patch']
+checksums = [
+    {'rustc-1.86.0-src.tar.gz': '022a27286df67900a044d227d9db69d4732ec3d833e4ffc259c4425ed71eed80'},
+    {'Rust-1.70_sysroot-fix-interpreter.patch': 'aa7a7fe784e463b297c640edfe88b8d96acbee0c173251575cef0426baccc57e'},
+]
+
+builddependencies = [
+    ('binutils', '2.42'),
+    ('CMake', '3.29.3'),
+    ('Python', '3.12.3'),
+    ('Ninja', '1.12.1'),
+    ('pkgconf', '2.2.0'),
+    ('patchelf', '0.18.0'),  # only required when RPATH linking is enabled
+]
+
+dependencies = [
+    ('OpenSSL', '3', '', SYSTEM),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
## Add `Rust 1.86.0-GCCcore-13.3.0`

Verbatim copy of the upstream EasyBuild recipe — no FH-side changes:
[`easybuilders/easybuild-easyconfigs:easybuild/easyconfigs/r/Rust/Rust-1.86.0-GCCcore-13.3.0.eb`](https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/Rust/Rust-1.86.0-GCCcore-13.3.0.eb).
This matches FH-repo convention: every prior `easyconfigs/r/Rust/Rust-*.eb` is also an upstream-verbatim copy.

Bumps the cluster's available Rust past 1.85, which the `edition2024` Cargo feature requires (current cluster max is `Rust/1.83.0-GCCcore-13.3.0`). GCCcore-13.3.0 matches the toolchain the cluster's existing Rust 1.83 is already built against, so no new toolchain or build-deps are introduced.

Source-tarball SHA256 verified against the authoritative `https://static.rust-lang.org/dist/rustc-1.86.0-src.tar.gz.sha256`:

```
022a27286df67900a044d227d9db69d4732ec3d833e4ffc259c4425ed71eed80  rustc-1.86.0-src.tar.gz
```

Diff under review (single new file, 31 LoC):
[`FredHutch/easybuild-life-sciences#main...katosh:dominik/rust-1.86.0-gcccore-13.3.0`](https://github.com/FredHutch/easybuild-life-sciences/compare/main...katosh:easybuild-life-sciences:dominik/rust-1.86.0-gcccore-13.3.0)
