### PR TITLE
passt: userspace network helper (closes #578)

### DIFF
--- a/easyconfigs/p/passt/passt-2026_05_07-GCCcore-13.3.0.eb
+++ b/easyconfigs/p/passt/passt-2026_05_07-GCCcore-13.3.0.eb
@@ -1,0 +1,71 @@
+# easybuild easyconfig
+#
+# Dominik Otto  dotto@fredhutch.org
+#
+# Fred Hutchinson Cancer Center
+#
+easyblock = 'ConfigureMake'
+
+name = 'passt'
+version = '2026_05_07'
+local_commit = '1afd4ed'
+
+homepage = 'https://passt.top/'
+description = """passt (Plug A Simple Socket Transport) and pasta (Pack A Subtle Tap
+ Abstraction) are unprivileged user-mode networking tools that translate between a
+ Layer-2 network interface (or a network namespace, in the case of pasta) and native
+ Layer-4 sockets on the host. They require no capabilities, kernel modules, or setuid
+ binaries, making them a drop-in replacement for slirp / slirp4netns in rootless
+ container and sandbox workflows. Dual-licensed GPL-2.0-or-later OR BSD-3-Clause."""
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://passt.top/passt/snapshot/']
+sources = ['%%(name)s-%%(version)s.%s.tar.gz' % local_commit]
+checksums = ['4b5cb8482db1a861bce36dafd4ba606565e1e294079c81d1e82e28f11e7a1f30']
+
+builddependencies = [
+    ('binutils', '2.42'),
+]
+
+# passt ships a plain Makefile, not autotools.
+skipsteps = ['configure']
+
+# Build only the two binaries needed for rootless-container / sandbox
+# networking. The upstream tree also ships `qrap` (qemu wrapper),
+# `passt-repair` (live-migration helper), and `pesto` (per-socket
+# traffic shaping); none is required for the use case driving this
+# module. Extend `local_bin` / `local_manpages` to reinstate them.
+#
+# NOTE: passt's source unconditionally `#include`s `<linux/vhost_types.h>`
+# (added in Linux 5.0) and `<linux/close_range.h>` (Linux 5.9) via
+# util.h -> packet.h -> virtio.h. The Ubuntu 18.04 build host that the
+# `gizmo-*-modules-18.04` modules target ships linux-libc-dev for the
+# 4.15 kernel and does not provide these headers. Compile here therefore
+# requires either (a) a newer linux-libc-dev / kernel-headers easyconfig
+# loaded as a build dependency, (b) a build host running Ubuntu 20.04+,
+# or (c) a passt patch making those includes conditional. See PR body
+# for the local build attempt that exposed this.
+#
+# The Makefile derives VERSION from `git describe`; snapshot tarballs
+# have no .git, so set VERSION explicitly to keep `--version` informative.
+local_bin = 'passt pasta'
+local_manpages = 'passt.1 pasta.1'
+buildopts = "VERSION=%%(version)s.%s BIN='%s' MANPAGES='%s'" % (
+    local_commit, local_bin, local_manpages,
+)
+installopts = "prefix=%%(installdir)s DESTDIR= BIN='%s' MANPAGES='%s'" % (
+    local_bin, local_manpages,
+)
+
+sanity_check_paths = {
+    'files': ['bin/passt', 'bin/pasta'],
+    'dirs': ['bin', 'share/man/man1'],
+}
+
+sanity_check_commands = [
+    'passt --version',
+    'pasta --version',
+]
+
+moduleclass = 'tools'


### PR DESCRIPTION
Closes FredHutch/easybuild-life-sciences#578.

Adds a `passt` easyconfig. `passt` (Plug A Simple Socket Transport) and
its sibling `pasta` (Pack A Subtle Tap Abstraction) are unprivileged
user-mode networking tools intended as a drop-in replacement for slirp /
slirp4netns. They translate between a Layer-2 interface (passt) or a
network namespace (pasta) and native Layer-4 sockets on the host, with
no capabilities, kernel modules, or setuid binaries required. The
immediate consumer is the sandbox workflow at
[katosh/agent_sandbox#52](https://github.com/katosh/agent_sandbox/pull/52),
which currently bundles its own out-of-tree `pasta` build.

| | |
|---|---|
| **Upstream** | https://passt.top/ |
| **Snapshot** | `2026_05_07.1afd4ed` (latest tag at submission; SHA256 verified) |
| **License** | GPL-2.0-or-later OR BSD-3-Clause (dual) |
| **Toolchain** | GCCcore-13.3.0, binutils 2.42 |
| **Easyblock** | `ConfigureMake` with `skipsteps = ['configure']` (upstream is plain Makefile) |
| **Module class** | `tools` |

### What ships

The easyconfig restricts the build to `passt` + `pasta` (and their
manpages); the upstream tree also produces `qrap` (qemu wrapper),
`passt-repair` (live-migration helper), and `pesto` (per-socket
traffic shaping), none of which are required for the rootless-sandbox
use case driving this request. Reinstating them is a one-line change
to `local_bin` / `local_manpages` in the easyconfig.

### Build test

Tested locally on `gizmok87` (Ubuntu 18.04, kernel 5.4) with EasyBuild
5.2.1:

- `eb --check-conflicts` → no conflicts.
- `eb --robot --dry-run` → all dependencies resolve against existing
  modules (M4, Bison, flex, zlib, binutils, GCCcore, help2man …).
- Source download + checksum verification → succeed.
- **Compile → fails on gizmo host.** passt unconditionally includes
  `<linux/vhost_types.h>` (kernel 5.0+) and `<linux/close_range.h>`
  (kernel 5.9+) via `util.h → packet.h → virtio.h`; Ubuntu 18.04's
  `linux-libc-dev` predates both.

### Remediation paths (for reviewer to pick)

1. Bump the build infrastructure to Ubuntu 20.04+ (`linux-libc-dev`
   ≥ 5.10) — likely the cleanest fix and benefits other recent
   userspace tools too.
2. Add a `linux-libc-headers` easyconfig that vendors the relevant
   UAPI headers and depend on it from this easyconfig.
3. Carry a small patch making the two `linux/*.h` includes conditional
   (`__has_include`) and providing fallback definitions for
   `CLOSE_RANGE_CLOEXEC`. Upstream may welcome it.

I'm happy to follow up with any of these once you confirm which path
fits the SciComp build pipeline. Flagged in the easyconfig itself in
a `# NOTE:` comment so future maintainers see the context.

### Sanity checks (post-install)

```python
sanity_check_paths = {
    'files': ['bin/passt', 'bin/pasta'],
    'dirs': ['bin', 'share/man/man1'],
}
sanity_check_commands = [
    'passt --version',
    'pasta --version',
]
```
